### PR TITLE
Refactor(.eslintrc): eslint 룰 적용되지 않는 문제 해결

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,8 +1,6 @@
 {
   "extends": [
-    "airbnb",
-    "airbnb/hooks",
-    "./eslint/index.js"
+    "./eslint/eslint.js"
   ],
   "parserOptions": {
     "requireConfigFile": false


### PR DESCRIPTION
## 주요 기능
- eslint 적용되지 않는 문제 해결

```
  "extends": [
    "airbnb",
    "airbnb/hooks",
    "./eslint/index.js"
  ],
```
기존에 eslint를 가져오는게 아니라 eslint, stylelint, prettier를 포괄하는 lint/index.js값을 가져오고 있었습니다.
eslint rules만 적용할 수 있는 eslint/eslint.js 를 가져옵니다. 중복해서 extends하는 airbnb, airbnb/hooks도 삭제하였습니다.

```
  "extends": [
    "./eslint/eslint.js"
  ],
```