### PR TITLE
refactor(emotion): emotion css prop 타입 추가

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "ESNext",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -24,15 +20,9 @@
     ],
     "paths": {
       "@*": ["./node_modules/@samilhero/design-system/src/*"]
-    }
+    },
+    "types": ["@emotion/react/types/css-prop"]
   },
-  "include": [
-    "next-env.d.ts",
-    "**/*.ts",
-    "**/*.tsx",
-    ".next/types/**/*.ts"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## 문제
![스크린샷 2024-04-01 오후 5 28 07](https://github.com/samilHero/missionary-client/assets/109706689/9232a363-f7b5-4ca1-b61f-ed3d4bc573b8)
- emotion css prop가 인식되지 않는 문제 발생
 
</br>
</br>

## 원인
- [@types/react/index.d.ts](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts#L1843-L1909)의 HTMLAttributes interface에 css 속성이 없는데, 추가하려고 하니 타입 에러가 발생

</br>
</br>

## 해결 방안
- tsconfig.base.json의 'compilerOptions'에 css-prop 타입 추가
``` json
{
  "compilerOptions": {
    "types": ["@emotion/react/types/css-prop"]
  }
}

```

</br>
</br>

## 결과
- 스트링 스타일 적용
![스크린샷 2024-04-01 오후 5 31 31](https://github.com/samilHero/missionary-client/assets/109706689/079d4165-e544-425d-9460-bb16682d37fe)
- 객체 스타일 적용
![스크린샷 2024-04-01 오후 5 32 18](https://github.com/samilHero/missionary-client/assets/109706689/140b14ea-5d2d-4997-a34a-4654f2bd95c4)
