### PR TITLE
Refactor(select): Select 컴포넌트를 제어 혹은 비제어컴포넌트로 스위칭이 가능하도록 수정

### DIFF
--- a/packages/design-system/src/components/select/index.tsx
+++ b/packages/design-system/src/components/select/index.tsx
@@ -14,7 +14,9 @@ import { SelectSearchInput } from './SelectSearchInput';
 import { SelectOptions } from './SelectOptions';
 import { SelectOption } from './SelectOption';
 import { forwardRefWithAs } from '@utils';
+import { useControllableState } from '@hooks';
 
+type ValueType = string | string[];
 export const SelectActionsContext = createContext<{
   setOpen: React.Dispatch<React.SetStateAction<boolean>>;
   handleSelectValue: (value: string) => void;
@@ -23,28 +25,33 @@ SelectActionsContext.displayName = 'SelectActionsContext';
 
 export const SelectDataContext = createContext<{
   open: boolean;
-  selectedValue: null | string | string[];
+  selectedValue?: ValueType;
 } | null>(null);
 SelectDataContext.displayName = 'SelectDataContext';
 
 interface SelectRootProps {
-  value: string | string[];
+  defaultValue?: ValueType;
+  value?: ValueType;
   multiple?: boolean;
   children?: React.ReactNode;
   className?: string;
-  onChange?(value: null | string | string[]): void;
+  onChange?(value?: ValueType): void;
 }
 const SelectRoot = ({
-  value,
-  onChange,
+  defaultValue,
+  value: controlledValue,
+  onChange: controlledOnChange,
   children,
   multiple = false,
 }: SelectRootProps) => {
   const selectRef = useRef<HTMLDivElement>(null);
   const [open, setOpen] = useState(false);
-  const [selectedValue, setSelectedValue] = useState<null | string | string[]>(
-    value,
-  );
+  let [selectedValue = multiple ? [] : undefined, setSelectedValue] =
+    useControllableState<ValueType>(
+      controlledValue,
+      controlledOnChange,
+      defaultValue,
+    );
 
   const handleSelectValue = useCallback(
     (item: string) => {
@@ -60,7 +67,6 @@ const SelectRoot = ({
       }
 
       setSelectedValue(selectedList);
-      onChange?.(selectedList);
     },
     [multiple, selectedValue],
   );

--- a/packages/design-system/src/components/select/index.tsx
+++ b/packages/design-system/src/components/select/index.tsx
@@ -16,7 +16,7 @@ import { SelectOption } from './SelectOption';
 import { forwardRefWithAs } from '@utils';
 import { useControllableState } from '@hooks';
 
-type ValueType = string | string[];
+type ValueType = string | string[] | undefined | null;
 export const SelectActionsContext = createContext<{
   setOpen: React.Dispatch<React.SetStateAction<boolean>>;
   handleSelectValue: (value: string) => void;

--- a/packages/design-system/src/hooks/index.tsx
+++ b/packages/design-system/src/hooks/index.tsx
@@ -3,3 +3,7 @@ export type { ContextData } from './useContextData';
 
 export { useContextAction } from './useContextAction';
 export type { ContextAction } from './useContextAction';
+
+export { useEvent } from './useEvent';
+export { useLatestValue } from './useLatestValue';
+export { useControllableState } from './useControllableState';

--- a/packages/design-system/src/hooks/useControllableState.tsx
+++ b/packages/design-system/src/hooks/useControllableState.tsx
@@ -37,7 +37,7 @@ export const useControllableState = <T,>(
 
   return [
     (isControlled ? controlledValue : internalValue)!,
-    useEvent((value) => {
+    useEvent((value: T) => {
       if (isControlled) {
         return onChange?.(value);
       } else {

--- a/packages/design-system/src/hooks/useControllableState.tsx
+++ b/packages/design-system/src/hooks/useControllableState.tsx
@@ -1,0 +1,49 @@
+import { useRef, useState } from 'react';
+import { useEvent } from './useEvent';
+
+export const useControllableState = <T,>(
+  controlledValue: T | undefined,
+  onChange?: (value: T) => void,
+  defaultValue?: T,
+) => {
+  let [internalValue, setInternalValue] = useState(defaultValue);
+
+  let isControlled = controlledValue !== undefined;
+  let wasControlled = useRef(isControlled);
+  let didWarnOnUncontrolledToControlled = useRef(false);
+  let didWarnOnControlledToUncontrolled = useRef(false);
+
+  if (
+    isControlled &&
+    !wasControlled.current &&
+    !didWarnOnUncontrolledToControlled.current
+  ) {
+    didWarnOnUncontrolledToControlled.current = true;
+    wasControlled.current = isControlled;
+    console.error(
+      'A component is changing from uncontrolled to controlled. This may be caused by the value changing from undefined to a defined value, which should not happen.',
+    );
+  } else if (
+    !isControlled &&
+    wasControlled.current &&
+    !didWarnOnControlledToUncontrolled.current
+  ) {
+    didWarnOnControlledToUncontrolled.current = true;
+    wasControlled.current = isControlled;
+    console.error(
+      'A component is changing from controlled to uncontrolled. This may be caused by the value changing from a defined value to undefined, which should not happen.',
+    );
+  }
+
+  return [
+    (isControlled ? controlledValue : internalValue)!,
+    useEvent((value) => {
+      if (isControlled) {
+        return onChange?.(value);
+      } else {
+        setInternalValue(value);
+        return onChange?.(value);
+      }
+    }),
+  ] as const;
+};

--- a/packages/design-system/src/hooks/useEvent.tsx
+++ b/packages/design-system/src/hooks/useEvent.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { useLatestValue } from './useLatestValue';
+
+export let useEvent =
+  // TODO: Add React.useEvent ?? once the useEvent hook is available
+  function useEvent<
+    F extends (...args: any[]) => any,
+    P extends any[] = Parameters<F>,
+    R = ReturnType<F>,
+  >(fn: (...args: P) => R) {
+    let cache = useLatestValue(fn);
+    return React.useCallback((...args: P) => cache.current(...args), [cache]);
+  };

--- a/packages/design-system/src/hooks/useLatestValue.tsx
+++ b/packages/design-system/src/hooks/useLatestValue.tsx
@@ -1,0 +1,11 @@
+import { useEffect, useRef } from 'react';
+
+export const useLatestValue = <T,>(value: T) => {
+  let cache = useRef(value);
+
+  useEffect(() => {
+    cache.current = value;
+  }, [value]);
+
+  return cache;
+};


### PR DESCRIPTION
## 주요 기능
- Select 컴포넌트가 제어 혹은 비제어 컴포넌트로 스위칭이 가능하도록 수정
- 비제어 및 제어 상태 값을 반환하는 useControllableState 훅 추가
  - [headlessUI](https://headlessui.com/react/menu) 라이브러리의 useControllable훅을 참고하였습니다.

제어 컴포넌트:
- 부모 컴포넌트에서 상태를 관리하는 방식
- 자식 컴포넌트들끼리 상태를 공유(의존성)되고 있으면 부모 컴포넌트에서 상태를 관리해야한다.
- 동적인 UI를 제공할 수 있다
- 상태가 바뀔 때 상태와 의존성이 없는 모든 컴포넌트가 re-rendering된다.

비제어 컴포넌트
- 자식 컴포넌트에서 상태관리를 하는 방식
- 상태가 바뀔 때 바뀐 컴포넌트만 re-rendering이 일어나고 나머지 컴포넌트는 re-rendering되지 않는다.
- 동적인 UI변화가 필요없을 때 유용하다.
- Form을 submit하는 시점에 데이터를 불러와서 값을 처리한다.

## 사용 방법
- useControllableState
```tsx
{ value, onChange } = useControllableState(props.defaultValue, props.value, props.onChange)
```

- Select Component 제어컴포넌트 형식
```tsx
const [value, setValue] = setState();

return (
  <Select value={value} onChange={setValue}>
    <Select.Trigger>Trigger</Select.Trigger>
    <Select.Options>
      <Select.Option item="1">Option 1</Select.Option>
      <Select.Option item="2">Option 2</Select.Option>
      <Select.Option item="3">Option 3</Select.Option>
    </Select.Options>
  </Select>
)
```

- Select Component 비제어컴포넌트 형식
```tsx
const ref = useRef()
const handleSubmit = (e: Event) => {
  e.preventValue();
  console.log(ref.current.value);
}

<from onSubmit={handleSubmit}>
    <Select ref={ref}>
      <Select.Trigger>Trigger</Select.Trigger>
      <Select.Options>
        <Select.Option item="1">Option 1</Select.Option>
        <Select.Option item="2">Option 2</Select.Option>
        <Select.Option item="3">Option 3</Select.Option>
      </Select.Options>
    </Select>
</form>
```

- Select Component 비제어컴포넌트 형식 (React-hook-form)
```tsx
const {register, handleSubmit} = useForm();

const onSubmit = (data) => {
  console.log(data);
}

<from onSubmit={handleSubmit(onSubmit)}>
    <Select {...register('select')}>
      <Select.Trigger>Trigger</Select.Trigger>
      <Select.Options>
        <Select.Option item="1">Option 1</Select.Option>
        <Select.Option item="2">Option 2</Select.Option>
        <Select.Option item="3">Option 3</Select.Option>
      </Select.Options>
    </Select>
</form>
```


래퍼런스
- [HeadlessUI 라이브러리, useControllable](https://github.com/tailwindlabs/headlessui/blob/main/packages/%40headlessui-react/src/hooks/use-controllable.ts)
- [제어 컴포넌트와 비제어 컴포넌트의 차이점](https://velog.io/@yukyung/React-%EC%A0%9C%EC%96%B4-%EC%BB%B4%ED%8F%AC%EB%84%8C%ED%8A%B8%EC%99%80-%EB%B9%84%EC%A0%9C%EC%96%B4-%EC%BB%B4%ED%8F%AC%EB%84%8C%ED%8A%B8%EC%9D%98-%EC%B0%A8%EC%9D%B4%EC%A0%90-%ED%86%BA%EC%95%84%EB%B3%B4%EA%B8%B0)
- [비제어 컴포넌트](https://ko.legacy.reactjs.org/docs/uncontrolled-components.html)
- [제어 컴포넌트](https://ko.legacy.reactjs.org/docs/forms.html#controlled-components)